### PR TITLE
add download widget

### DIFF
--- a/examples/metadata-basic.html
+++ b/examples/metadata-basic.html
@@ -61,7 +61,19 @@
                         { format: 'APA', text: "O'Neil, J. M. (1992). <em>Men's and women's gender role journeys: A metaphor for healing, transition, and transformation.</em> New York, NY: Springer." },
                         { format: 'Chicago', text: 'Faulkner, William. <em>Absalom, Absalom!</em>. New York: Vintage Books, 1990.' }
                     ]
-                }
+                },
+                download_links: [
+                    {
+                        format: 'EPUB',
+                        size: '22 MB',
+                        href: 'https://archive.org/download/greeklivesfrompl00plutuoft/greeklivesfrompl00plutuoft.epub'
+                    },
+                    {
+                        format: 'PDF',
+                        size: '12 MB',
+                        href: 'https://archive.org/download/greeklivesfrompl00plutuoft/greeklivesfrompl00plutuoft.pdf'
+                    }
+                ]
             });
 
             cozy.control.title({ region: 'top.header.left' }).addTo(reader);
@@ -76,6 +88,7 @@
             }).addTo(reader);
 
             cozy.control.citationOptions({ region: 'top.toolbar.left' }).addTo(reader);
+            cozy.control.download({ region: 'top.toolbar.left' }).addTo(reader);
 
             cozy.control.preferences({ region: 'top.toolbar.right' }).addTo(reader);
             // cozy.control.pageFirst({ region: 'left.sidebar' }).addTo(reader);

--- a/spec/control/Control.DownloadSpec.js
+++ b/spec/control/Control.DownloadSpec.js
@@ -1,0 +1,54 @@
+describe("Control.Download", function () {
+  var reader;
+  var options = { region: 'top.toolbar.left' };
+
+  var download_epub_link = 'https://archive.org/download/greeklivesfrompl00plutuoft/greeklivesfrompl00plutuoft.epub';
+  var download_pdf_link = 'https://archive.org/download/greeklivesfrompl00plutuoft/greeklivesfrompl00plutuoft.pdf';
+
+  beforeEach(function() {
+    reader = cozy.reader(document.createElement('div'), {
+      engine: 'mock',
+      href: 'mock.epub',
+      download_links: [
+          {
+              format: 'EPUB',
+              size: '22 MB',
+              href: download_epub_link
+          },
+          {
+              format: 'PDF',
+              size: '12 MB',
+              href: download_pdf_link
+          }
+        ]
+    });    
+  });
+
+  it("can be added to an unloaded reader", function () {
+    new cozy.Control.Download(options).addTo(reader);
+  });
+
+  it("can be added and use the download links via modal", function () {
+    var control = new cozy.Control.Download(options).addTo(reader);
+    reader.start();
+    happen.click(control._control);
+
+    var possibles = 
+      [
+        [ 'EPUB', download_epub_link ],
+        [ 'PDF', download_pdf_link ]
+      ];
+
+    for(var i in possibles) {
+      var value = possibles[i][0];
+      var test = possibles[i][1];
+
+      control._configureDownloadForm(test);
+      var form = control._form;
+
+      expect(form.getAttribute("action")).to.be(test);
+    }
+
+  });
+});
+

--- a/src/control/Control.Download.js
+++ b/src/control/Control.Download.js
@@ -1,0 +1,112 @@
+import {Control} from './Control';
+import {Reader} from '../reader/Reader';
+import * as DomUtil from '../dom/DomUtil';
+import * as DomEvent from '../dom/DomEvent';
+
+export var Download = Control.extend({
+  options: {
+    label: 'Download Book',
+    html: '<span>Download Book</span>'
+  },
+
+  defaultTemplate: `<button class="button--sm cozy-download oi" data-toggle="open" data-glyph="data-transfer-download"> Download Book</button>`,
+
+
+  onAdd: function(reader) {
+    var self = this;
+    var container = this._container;
+    if ( container ) {
+      this._control = container.querySelector("[data-target=" + this.options.direction + "]");
+    } else {
+
+      var className = this._className(),
+          options = this.options;
+
+      container = DomUtil.create('div', className);
+
+      var template = this.options.template || this.defaultTemplate;
+
+      var body = new DOMParser().parseFromString(template, "text/html").body;
+      while ( body.children.length ) {
+        container.appendChild(body.children[0]);
+      }
+    }
+
+    this._reader.on('update-contents', function(data) {
+      self._createPanel();
+    });
+
+
+    this._control = container.querySelector("[data-toggle=open]");
+    DomEvent.on(this._control, 'click', function(event) {
+      event.preventDefault();
+      self._modal.activate();
+    }, this)
+
+    return container;
+  },
+
+  _createPanel: function() {
+    var self = this;
+
+    var template = `<form>
+      <fieldset>
+        <legend>Choose File Format</legend>
+      </fieldset>
+    </form>`;
+
+    this._modal = this._reader.modal({
+      template: template,
+      title: 'Download Book',
+      className: { article: 'cozy-preferences-modal' },
+      actions: [
+        {
+          label: 'Download',
+          callback: function(event) {
+            var selected = self._form.querySelector("input:checked");
+            var href = selected.getAttribute('data-href');
+            self._configureDownloadForm(href);
+            self._form.submit();
+          }
+        }
+      ],
+      region: 'left',
+      fraction: 1.0
+    });
+
+    this._form = this._modal._container.querySelector('form');    
+    var fieldset = this._form.querySelector('fieldset');
+    this._reader.options.download_links.forEach(function(link, index) {
+      var label = DomUtil.create('label', null, fieldset);
+      var input = DomUtil.create('input', null, label);
+      input.setAttribute('name', 'format');
+      input.setAttribute('value', link.format);
+      input.setAttribute('data-href', link.href);
+      input.setAttribute('type', 'radio');
+      if ( index == 0 ) {
+        input.setAttribute('checked', 'checked');
+      }
+      var text = link.format;
+      if ( link.size ) {
+        text += " (" + link.size + ")";
+      }
+      var text = document.createTextNode(" " + text);
+      label.appendChild(text);
+    });
+
+  },
+
+  _configureDownloadForm: function(href) {
+    var self = this;
+    self._form.setAttribute('method', 'GET');
+    self._form.setAttribute('action', href);
+    self._form.setAttribute('target', '_blank');
+  },
+
+
+  EOT: true
+});
+
+export var download = function(options) {
+  return new Download(options);
+}

--- a/src/control/index.js
+++ b/src/control/index.js
@@ -7,6 +7,7 @@ import {Preferences, preferences} from './Control.Preferences';
 import {Widget, widget} from './Control.Widget';
 import {Citation, citation} from './Control.Citation';
 import {CitationOptions, citationOptions} from './Control.CitationOptions';
+import {Download, download} from './Control.Download';
 
 // import {Zoom, zoom} from './Control.Zoom';
 // import {Attribution, attribution} from './Control.Attribution';
@@ -40,5 +41,8 @@ control.citation = citation;
 
 Control.CitationOptions = CitationOptions;
 control.citationOptions = citationOptions;
+
+Control.Download = Download;
+control.download = download;
 
 export {Control, control};


### PR DESCRIPTION
- expects download links to be passed as part of the Reader options, e.g.

```
                download_links: [
                    {
                        format: 'EPUB',
                        size: '22 MB',
                        href: 'https://archive.org/download/greeklivesfrompl00plutuoft/greeklivesfrompl00plutuoft.epub'
                    },
                    {
                        format: 'PDF',
                        size: '12 MB',
                        href: 'https://archive.org/download/greeklivesfrompl00plutuoft/greeklivesfrompl00plutuoft.pdf'
                    }
                ]
```

**THIS DOES NOT INCLUDE THE COMPILED JS.**

Resolves #41