### PR TITLE
catching odd scrolling

### DIFF
--- a/src/reader/Reader.EpubJS.js
+++ b/src/reader/Reader.EpubJS.js
@@ -212,6 +212,22 @@ Reader.EpubJS = Reader.extend({
           self._rendition.display(href);
         })
       }
+      if ( ! self._rendition.manager.__scroll ) {
+        var ticking;
+        self._rendition.manager.container.addEventListener("scroll", function(event) {
+          if ( ! ticking ) {
+            var mod = event.target.scrollLeft % parseInt(self._rendition.manager.layout.delta, 10);
+            if ( mod > 0 ) {
+              ticking = true;
+              var x = Math.floor(event.target.scrollLeft / parseInt(self._rendition.manager.layout.delta, 10)) + 1;
+              var delta = ( x * self._rendition.manager.layout.delta) - event.target.scrollLeft;
+              self._rendition.manager.scrollBy(delta);
+              setTimeout(function() { ticking = false; }, 100);
+            }
+          }
+        })
+        self._rendition.manager.views.__scroll = true;
+      }
       window.location.hash = "#/"+self._book.url.path().relative(section.href);
     })
   },


### PR DESCRIPTION
Not quite a hack to address the half-scrolling that happens if the user is tabbing through a heavily linked epub.

Fixes #83.
