### PR TITLE
add -webkit-overflow-scrolling: touch

### DIFF
--- a/dist/cozy-sun-bear.css
+++ b/dist/cozy-sun-bear.css
@@ -1507,7 +1507,8 @@
 .epub-container {
   /* background: blue; */
   /* -- padding on this container messes with horizontal scrolling */
-  /*padding: 20px;*/ }
+  /*padding: 20px;*/
+  -webkit-overflow-scrolling: touch; }
 
 div[class^='cozy-panel-'] {
   display: flex;

--- a/examples/example.html
+++ b/examples/example.html
@@ -45,6 +45,14 @@
             text-overflow: ellipsis;
         }
 
+        .u-screenreader {
+          clip: rect(1px, 1px, 1px, 1px);
+          height: 1px;
+          overflow: hidden;
+          position: absolute !important;
+          width: 1px;
+        }
+
         @media only screen and (min-device-width : 320px) and (max-device-width : 600px) {
             .cozy-module-book {
                 width: 100vw;

--- a/scss/cozy.scss
+++ b/scss/cozy.scss
@@ -373,6 +373,7 @@ $grid-padding:       1rem;
   /* background: blue; */
   /* -- padding on this container messes with horizontal scrolling */
   /*padding: 20px;*/
+  -webkit-overflow-scrolling: touch;
 }
 
 div[class^='cozy-panel-'] {


### PR DESCRIPTION
- add `-webkit-overflow-scrolling: touch`
- fix `example.html` so engine selection doesn't interfere with submitting the EPUB selection

Fixes #106