### PR TITLE
plug into rendition events

### DIFF
--- a/src/reader/Reader.js
+++ b/src/reader/Reader.js
@@ -110,12 +110,13 @@ export var Reader = Evented.extend({
 
     self.open(function() {
       self.setBookPanelSize();
-      self.draw(target, function() {
-        self._panes['loader'].style.display = 'none';
-        if ( cb ) {
-          cb();
-        }
-      });
+      self.draw(target, cb);
+      // self.draw(target, function() {
+      //   self._panes['loader'].style.display = 'none';
+      //   if ( cb ) {
+      //     cb();
+      //   }
+      // });
     });
   },
 


### PR DESCRIPTION
Fixes #115 Exposes a way to plug into the epub.js rendition hooks, e.g.

```
var click_handler = function(target) { ... };
reader.on('ready:contents', function(contents) {
    var links = contents.content.querySelectorAll("a[data-uid]");
    for(var i =0, n = links.length; i < n; i++) {
       var link = links[i];
       link.addEventListener('click', click_handler);
    }
})

reader.start();
```

Fixes #120 navigation is handled in a more consistent fashion. If the reader is initiated with a bad location, the book is opened to the first page. If the reader is already displaying content and tries to navigate to a bad location, nothing changes.