### PR TITLE
width of prev/next buttons was too wide, overflowing width of column

### DIFF
--- a/dist/cozy-sun-bear.css
+++ b/dist/cozy-sun-bear.css
@@ -911,6 +911,25 @@
 .modal-slide .modal__overlay {
   will-change: transform; }
 
+@keyframes modal-spinner {
+  to {
+    transform: rotate(360deg); } }
+
+.modal-slide .spinner:before {
+  content: '';
+  box-sizing: border-box;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 100px;
+  height: 100px;
+  margin-top: -50px;
+  margin-left: -50px;
+  border-radius: 50%;
+  border: 2px solid #ccc;
+  border-top-color: #333;
+  animation: modal-spinner .6s linear infinite; }
+
 @media screen and (min-width: 50em) {
   .modal__container {
     width: 40%; } }
@@ -1552,7 +1571,7 @@ div.cozy-panel-footer {
   float: right; }
 
 .cozy-panel-sidebar .cozy-control a {
-  width: 100px;
+  width: auto;
   display: inline-block;
   background: transparent;
   text-align: center;

--- a/scss/cozy.scss
+++ b/scss/cozy.scss
@@ -441,7 +441,7 @@ div.cozy-panel-footer {
 
 // previous, next buttons
 .cozy-panel-sidebar .cozy-control a {
-  width: 100px;
+  width: auto;
   display: inline-block;
   background: transparent;
   text-align: center;


### PR DESCRIPTION
Resolves [Heliotrope#1680](https://github.com/mlibrary/heliotrope/issues/1680).

**Note: Not sure how that bit of CSS at line 914 got in there, but guessing the last time someone edited cozy.scss they did not build the css file.**