### PR TITLE
nest flexes to solve bug #78 with safari

### DIFF
--- a/dist/cozy-sun-bear.css
+++ b/dist/cozy-sun-bear.css
@@ -1224,6 +1224,8 @@
 .cozy-container .cozy-panel-navigator {
   width: 100%;
   margin: 0 auto; }
+  .cozy-container .cozy-panel-navigator .cozy-control {
+    display: block; }
   .cozy-container .cozy-panel-navigator .cozy-control-navigator {
     width: 100%;
     opacity: 0;
@@ -1547,22 +1549,27 @@ div.cozy-panel-footer {
 .cozy-module-top .cozy-panel-toolbar .cozy-panel-right {
   justify-content: flex-end; }
 
-.cozy-control .cozy-h1 {
-  font-family: 'Scope One', Georgia, Times, "Times New Roman", serif;
-  margin: .3em .5em 0;
-  font-size: 1.5em;
-  line-height: normal;
-  max-width: 95vw;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis; }
-
-.cozy-control button.button--sm {
-  font-size: 1em;
-  height: 100%;
-  border-radius: 0;
-  padding: 0 1em;
-  text-transform: uppercase; }
+.cozy-control {
+  display: flex; }
+  .cozy-control .cozy-h1 {
+    font-family: 'Scope One', Georgia, Times, "Times New Roman", serif;
+    margin: .3em .5em 0;
+    font-size: 1.5em;
+    line-height: normal;
+    max-width: 95vw;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis; }
+  .cozy-control button.button--sm {
+    font-size: 1em;
+    display: flex;
+    flex: 1 1 auto;
+    border-radius: 0;
+    padding: .5em 1em;
+    text-transform: uppercase; }
+    .cozy-control button.button--sm i {
+      display: flex;
+      flex: 1 1 auto; }
 
 .cozy-publisher {
   float: left; }
@@ -1635,7 +1642,7 @@ div.cozy-panel-footer {
   display: inline-flex;
   height: 100%; }
   .cozy-control form.search button.button--sm {
-    padding: 0 .5em; }
+    padding: .5em .5em; }
   .cozy-control form.search button i.icon-magnifying-glass {
     font-size: 1em; }
 

--- a/scss/_navigator.scss
+++ b/scss/_navigator.scss
@@ -22,6 +22,10 @@
   width: 100%;
   margin: 0 auto;
 
+  .cozy-control {
+    display: block;
+  }
+
   .cozy-control-navigator {
 
     width: 100%;

--- a/scss/cozy.scss
+++ b/scss/cozy.scss
@@ -407,6 +407,7 @@ div.cozy-panel-footer {
 }
 
 .cozy-control {
+  display: flex;
   .cozy-h1 {
     @include scope-one;
     margin: .3em .5em 0;
@@ -420,11 +421,20 @@ div.cozy-panel-footer {
 
   button.button--sm {
     font-size: 1em;
-    height: 100%;
+    display: flex;
+    flex: 1 1 auto;
+    // height: 100%;
     border-radius: 0;
-    padding: 0 1em;
+    padding: .5em 1em;
     text-transform: uppercase;
+
+    i {
+      display: flex;
+      flex: 1 1 auto;
+    }
+
   }
+
 }
 
 ///////////////////////////////////
@@ -519,7 +529,7 @@ div.cozy-panel-footer {
   height: 100%;
 
   button.button--sm {
-    padding: 0 .5em;
+    padding: .5em .5em;
   }
 
   button i.icon-magnifying-glass {
@@ -536,17 +546,17 @@ div.cozy-panel-footer {
 }
 
 .cozy-modal fieldset p {
-  width: 90%; 
+  width: 90%;
   margin: 0 auto;
   text-align: center;
 }
 
 .preview--text_size {
-  width: 90%; 
-  height: 8rem; 
-  margin: 1rem auto; 
-  border: 1px dotted #666; 
-  padding: 1rem; 
+  width: 90%;
+  height: 8rem;
+  margin: 1rem auto;
+  border: 1px dotted #666;
+  padding: 1rem;
   overflow: hidden;
 }
 


### PR DESCRIPTION
Resolves #78 

Sets `.cozy-control` and children `button`s and `i`s to `display: flex;  flex: 1 1 auto` ;  minor tweaks to `padding-top` of buttons and display of navigation controls to correct IE11 rendering.